### PR TITLE
fix: move error creation

### DIFF
--- a/packages/libp2p-peer-id/src/index.ts
+++ b/packages/libp2p-peer-id/src/index.ts
@@ -151,8 +151,6 @@ export function createPeerId (init: PeerIdInit) {
 }
 
 export function peerIdFromPeerId (other: any): PeerId {
-  const err = errcode(new Error('Not a PeerId'), 'ERR_INVALID_PARAMETERS')
-
   if (other.type === 'RSA') {
     return new RSAPeerIdImpl(other)
   }
@@ -165,7 +163,7 @@ export function peerIdFromPeerId (other: any): PeerId {
     return new Secp256k1PeerIdImpl(other)
   }
 
-  throw err
+  throw errcode(new Error('Not a PeerId'), 'ERR_INVALID_PARAMETERS')
 }
 
 export function peerIdFromString (str: string, decoder?: MultibaseDecoder<any>): PeerId {


### PR DESCRIPTION
Only intantiate error if we are going to throw it.