### PR TITLE
chore: replace err-code with CodeError

### DIFF
--- a/packages/libp2p-peer-id/package.json
+++ b/packages/libp2p-peer-id/package.json
@@ -139,7 +139,7 @@
   },
   "dependencies": {
     "@libp2p/interface-peer-id": "^2.0.0",
-    "err-code": "^3.0.1",
+    "@libp2p/interfaces": "^3.2.0",
     "multiformats": "^11.0.0",
     "uint8arrays": "^4.0.2"
   },

--- a/packages/libp2p-peer-id/src/index.ts
+++ b/packages/libp2p-peer-id/src/index.ts
@@ -5,7 +5,7 @@ import * as Digest from 'multiformats/hashes/digest'
 import { identity } from 'multiformats/hashes/identity'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { sha256 } from 'multiformats/hashes/sha2'
-import errcode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { Ed25519PeerId, PeerIdType, RSAPeerId, Secp256k1PeerId, symbol } from '@libp2p/interface-peer-id'
 import type { MultibaseDecoder } from 'multiformats/bases/interface'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
@@ -177,7 +177,7 @@ export function createPeerId (init: PeerIdInit): PeerId {
     return new Secp256k1PeerIdImpl(init)
   }
 
-  throw errcode(new Error('Type must be "RSA", "Ed25519" or "secp256k1"'), 'ERR_INVALID_PARAMETERS')
+  throw new CodeError('Type must be "RSA", "Ed25519" or "secp256k1"', 'ERR_INVALID_PARAMETERS')
 }
 
 export function peerIdFromPeerId (other: any): PeerId {
@@ -193,7 +193,7 @@ export function peerIdFromPeerId (other: any): PeerId {
     return new Secp256k1PeerIdImpl(other)
   }
 
-  throw errcode(new Error('Not a PeerId'), 'ERR_INVALID_PARAMETERS')
+  throw new CodeError('Not a PeerId', 'ERR_INVALID_PARAMETERS')
 }
 
 export function peerIdFromString (str: string, decoder?: MultibaseDecoder<any>): PeerId {


### PR DESCRIPTION
Replaces [err-code](https://github.com/IndigoUnited/js-err-code/blob/master/index.js) with [CodeError](https://github.com/libp2p/js-libp2p-interfaces/pull/314)

Related: [#1269](https://github.com/libp2p/js-libp2p/issues/1269)

Changes (only affect peer-id package)

- added @libp2p/interfaces@3.2.0 to the to use the new CodeError export
- removes err-code from dependencies
- uses CodeError in place of err-code
